### PR TITLE
MOD: [nwafuSimple] 改善 frame subtitle 为空时的输出效果

### DIFF
--- a/nwafuSimple/beamerouterthemenwafusimple.sty
+++ b/nwafuSimple/beamerouterthemenwafusimple.sty
@@ -85,8 +85,14 @@
   % 帧标题
   \setbeamertemplate{frametitle}{%
     \begin{minipage}[c][\beamer@height][c]{\textwidth-1.5\beamer@logoouterradius}
-      \hspace*{-2ex}{\usebeamercolor[fg]{frametitle}\usebeamerfont{frametitle}\insertframetitle}
-      \ |\ {\usebeamercolor[fg]{framesubtitle}\usebeamerfont{frametitle}\insertframesubtitle\par}%
+      \hspace*{-2ex}%
+      \usebeamercolor[fg]{frametitle}\usebeamerfont{frametitle}\insertframetitle
+      \ifx\insertframesubtitle\@empty
+      \else
+        \ |\ 
+        \usebeamercolor[fg]{framesubtitle}\usebeamerfont{frametitle}\insertframesubtitle
+      \fi
+      \par
     \end{minipage}
   }
   


### PR DESCRIPTION
修改前
 - frame subtitle 为空时，输出 `<title> <space> <space> | <space>`
 - 不为空时，输出 `<title> <space> <space> | <space> <subtitle>`

修改后
 - frame subtitle 为空时，输出 `<title>`，不再输出 `|`
 - 不为空时，输出 `<title> <space> | <space> <subtitle>`

其他调整
 - 原来在 <title> 和 | 之间有两个空格（由换行符 + `\ ` 产生），现恢复为一个
 - 去掉了额外分组，和之前的唯一差异是，`<space> | <space>` 这三个字符将和 `<title>` 使用相同的字体和颜色